### PR TITLE
Implement trading mechanics with tests

### DIFF
--- a/Chart_Lab/services/simulator.py
+++ b/Chart_Lab/services/simulator.py
@@ -1,35 +1,86 @@
-# ──────────────────── services/simulator.py (핵심 변경) ────────────────────
-"""Only the modified parts are shown – rest of the class stays the same."""
+"""Simple trading simulator components used by the Streamlit app."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+
+
+@dataclass
+class Position:
+    """Represents a single long or short position."""
+
+    side: str  # "long" or "short"
+    qty: int
+    entry: float
+
+    def market_value(self, price: float) -> float:
+        """Return the directional market value of the position."""
+        direction = 1 if self.side == "long" else -1
+        return self.qty * price * direction
+
+    def unreal(self, price: float) -> float:
+        """Calculate unrealized PnL at the given price."""
+        direction = 1 if self.side == "long" else -1
+        return (price - self.entry) * self.qty * direction
+
+    def close(self, price: float) -> float:
+        """Close the position and return realized PnL."""
+        return self.unreal(price)
+
+
 class GameState:
-    def __init__(self, df, idx: int, start_cash: int = 100_000, tkr: str | None = None):
+    """Holds the state for a trading simulation."""
+
+    def __init__(self, df: pd.DataFrame, idx: int, start_cash: int = 100_000, tkr: Optional[str] = None) -> None:
         self.df = df
         self.idx = idx
         self.initial_cash = start_cash
-        self.cash = start_cash
-        self.pos = None  # Position object or None
-        self.log = []
-        # store the ticker symbol if provided
-        self.ticker = tkr if tkr is not None else ""
+        self.cash = float(start_cash)
+        self.pos: Optional[Position] = None
+        self.log: List[Dict[str, Any]] = []
+        self.ticker = tkr.upper() if tkr else ""
 
-    # ... today, next_candle methods unchanged ...
+    @property
+    def today(self) -> pd.Timestamp:
+        """Current date in the price data."""
+        return self.df.index[self.idx]
 
-    def buy(self, qty: int):
-        px = self.df.Close.iloc[self.idx]
-        self.pos = Position("long", qty, px, self.pos)
-        self.log.append({"date": self.today, "action": "ENTER LONG", "price": px, "qty": qty})
+    def next_candle(self) -> bool:
+        """Advance to the next bar. Returns False if at the end."""
+        if self.idx + 1 >= len(self.df):
+            return False
+        self.idx += 1
+        return True
 
-    def sell(self, qty: int):
-        px = self.df.Close.iloc[self.idx]
-        self.pos = Position("short", qty, px, self.pos)
-        self.log.append({"date": self.today, "action": "ENTER SHORT", "price": px, "qty": qty})
+    def _price(self) -> float:
+        return float(self.df.Close.iloc[self.idx])
 
-    def flat(self):
+    def buy(self, qty: int) -> None:
+        """Enter a long position at the current price."""
+        price = self._price()
+        self.pos = Position("long", qty, price)
+        self.log.append({"date": self.today, "action": "ENTER LONG", "price": price, "qty": qty})
+
+    def sell(self, qty: int) -> None:
+        """Enter a short position at the current price."""
+        price = self._price()
+        self.pos = Position("short", qty, price)
+        self.log.append({"date": self.today, "action": "ENTER SHORT", "price": price, "qty": qty})
+
+    def flat(self) -> None:
+        """Exit any open position and realise PnL."""
         if not self.pos:
             return
-        px = self.df.Close.iloc[self.idx]
-        pnl = self.pos.close(px)
+        price = self._price()
+        pnl = self.pos.close(price)
         self.cash += pnl
-        self.log.append({"date": self.today, "action": "EXIT", "price": px, "pnl": pnl})
+        self.log.append({"date": self.today, "action": "EXIT", "price": price, "pnl": pnl})
         self.pos = None
 
-# Position class는 market_value(), unreal() 헬퍼 메서드를 갖고 있다고 가정
+    @property
+    def equity(self) -> float:
+        """Return cash plus unrealised PnL."""
+        unreal = self.pos.unreal(self._price()) if self.pos else 0.0
+        return self.cash + unreal

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from Chart_Lab.services.simulator import GameState
+
+
+def make_df():
+    data = {
+        "Open": [100, 105, 110],
+        "High": [101, 106, 111],
+        "Low": [99, 104, 109],
+        "Close": [100, 105, 110],
+        "Volume": [1000, 1000, 1000],
+    }
+    idx = pd.date_range("2020-01-01", periods=3)
+    return pd.DataFrame(data, index=idx)
+
+
+def test_buy_flat_updates_cash():
+    df = make_df()
+    g = GameState(df, idx=0, start_cash=1000)
+    g.buy(1)
+    g.next_candle()
+    g.next_candle()
+    g.flat()
+    assert g.cash == 1010
+    assert g.pos is None
+
+
+def test_sell_flat_updates_cash():
+    df = make_df()
+    g = GameState(df, idx=0, start_cash=1000)
+    g.sell(1)
+    g.next_candle()
+    g.next_candle()
+    g.flat()
+    assert g.cash == 990
+    assert g.pos is None
+
+
+def test_next_candle_and_today():
+    df = make_df()
+    g = GameState(df, idx=0, start_cash=1000)
+    first_day = g.today
+    g.next_candle()
+    assert g.today > first_day


### PR DESCRIPTION
## Summary
- flesh out `GameState` with progression helpers
- add `Position` class with value/PnL helpers
- create unit tests for trading logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68500fa080ac83239d4a2b0a8cf5accc