### PR TITLE
Enable rangebreaks on chart

### DIFF
--- a/Chart_Lab/app.py
+++ b/Chart_Lab/app.py
@@ -252,6 +252,7 @@ fig.update_layout(
     xaxis_rangeslider_visible=False,
     margin=dict(t=40, b=20, l=10, r=10),
 )
+fig.update_xaxes(rangebreaks=[dict(bounds=["sat", "mon"])])
 
 chart_col.plotly_chart(fig, use_container_width=True)
 


### PR DESCRIPTION
## Summary
- skip weekends on the Plotly x-axis so charts show no gaps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850121afbc883239f78fbc3cd7c80f5