### PR TITLE
Implement MA color mapping

### DIFF
--- a/Chart_Lab/app.py
+++ b/Chart_Lab/app.py
@@ -194,6 +194,9 @@ mas = [("EMA", int(p)) for p in ema_txt.split(',') if p.strip().isdigit()] + \
       [("SMA", int(p)) for p in sma_txt.split(',') if p.strip().isdigit()]
 mas_tuple = tuple((k, p, True) for k, p in mas)  # 3rd bool=plot flag
 
+# default colors for common moving averages
+ma_colors = {"EMA10": "red", "EMA21": "blue", "SMA50": "orange", "SMA200": "black"}
+
 # --- data & indicators
 df_price = load_price(g.ticker)
 if df_price is None:
@@ -240,7 +243,12 @@ fig.add_trace(
 
 for col in [c for c in vis_df.columns if c.startswith(("EMA", "SMA"))]:
     fig.add_trace(
-        go.Scatter(x=vis_df.index, y=vis_df[col], name=col, line=dict(width=1)),
+        go.Scatter(
+            x=vis_df.index,
+            y=vis_df[col],
+            name=col,
+            line=dict(width=1, color=ma_colors.get(col, "gray")),
+        ),
         row=1,
         col=1,
     )


### PR DESCRIPTION
## Summary
- add a default color map for common moving averages
- use the map when plotting MA lines so each has a consistent color

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850160a1a0483238874473bbff3d9cd