### PR TITLE
Apply fixedrange to price axis

### DIFF
--- a/Chart_Lab/app.py
+++ b/Chart_Lab/app.py
@@ -220,6 +220,7 @@ fig = make_subplots(
     vertical_spacing=0.03,
     row_heights=[0.7, 0.3],
 )
+fig.update_yaxes(fixedrange=True, row=1, col=1)
 
 fig.add_trace(
     go.Candlestick(


### PR DESCRIPTION
## Summary
- lock candlestick y-axis zoom by setting `fixedrange=True`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68501609dcc483239db38e3865974859