### PR TITLE
Add average price tracking

### DIFF
--- a/Chart_Lab/app.py
+++ b/Chart_Lab/app.py
@@ -245,6 +245,9 @@ for col in [c for c in vis_df.columns if c.startswith(("EMA", "SMA"))]:
         col=1,
     )
 
+if g.pos is not None and g.avg_price is not None:
+    fig.add_hline(y=g.avg_price, line=dict(color="orange", dash="dash"), row=1, col=1)
+
 fig.add_trace(
     go.Bar(x=vis_df.index, y=vis_df.Volume, name="Volume"),
     row=2,

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -46,3 +46,16 @@ def test_next_candle_and_today():
     first_day = g.today
     g.next_candle()
     assert g.today > first_day
+
+
+def test_avg_price_accumulates():
+    df = make_df()
+    g = GameState(df, idx=0, start_cash=1000)
+    g.buy(1)
+    g.next_candle()
+    g.buy(1)
+    assert g.pos.qty == 2
+    assert g.avg_price == 102.5
+    g.next_candle()
+    g.flat()
+    assert g.cash == 1015


### PR DESCRIPTION
## Summary
- accumulate long positions with weighted average entry
- expose `GameState.avg_price` and reset when flat
- draw average entry line on chart when a position is open
- test averaging logic

## Testing
- `pip install -q -r Chart_Lab/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68501608fc488323bdfd7097c4cab0d7